### PR TITLE
Fix complete message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM centos:7
+
+MAINTAINER Tatsuya Saito <twopackas@gmail.com>
+
+RUN yum install -y epel-release && \
+    yum-config-manager --enable epel
+
+RUN rm -f /etc/rpm/macros.image-language-conf && \
+    sed -i '/^override_install_langs=/d' /etc/yum.conf && \
+    yum -y reinstall glibc-common && \
+    yum clean all
+
+ENV LANG="ja_JP.UTF-8" \
+    LANGUAGE="ja_JP:ja" \
+    LC_ALL="ja_JP.UTF-8"
+
+RUN yum install -y which && \
+    yum install -y selinux-policy && \
+    yum install -y firewalld && \
+    yum install -y ansible git
+
+WORKDIR /tmp
+RUN git clone -b 3.4-unofficialcooking https://github.com/y503unavailable/redmine-centos-ansible.git
+
+WORKDIR /tmp/redmine-centos-ansible

--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ redmine_default_theme: redmine_flat
 
 ---
 
+### Dockerを使用したPlaybookの実行
+
+下記のコマンドでPlaybookを実行できるDockerコンテナのビルドができます。
+```
+$ git clone https://github.com/y503unavailable/redmine-centos-ansible.git
+$ cd redmine-centos-ansible
+$ docker build -t redmine-centos-ansible .
+```
+
+下記のコマンドでビルドしたDockerコンテナでPlaybookを実行できます。
+```
+$ docker run --privileged --name redmine-centos-ansible -d -p 8080:80 redmine-centos-ansible /sbin/init
+$ docker exec -ti redmine-centos-ansible /bin/bash
+＜コンテナに入ると、リポジトリをチェックアウトした状態のフォルダがカレントになっています。＞
+＜ここで上記に従い、パスワードの変更などを行ってください。＞
+# ansible-playbook -i hosts site.yml
+```
+
+Webブラウザで `http://サーバIPアドレス:8080/redmine` にアクセスしてください。Redmineの画面が表示されるはずです。
+
 ## ライセンス
 
 MIT License

--- a/site.yml
+++ b/site.yml
@@ -9,8 +9,8 @@
     - redmine-plugins
     - redmine-themes
   post_tasks:
-    - debug: msg='Redmine instalation completed. access http://{{ ansible_default_ipv4.address }}/redmine/ '
-    - debug: msg='admin initial passwotd= {{ redmine_admin_passwd }} '
+    - debug: msg="Redmine installation completed. Access http{{':'}}//{{ ansible_default_ipv4.address }}/redmine/ "
+    - debug: msg="admin initial password= {{ redmine_admin_passwd }} "
 
 - name: fess サーバ構築
   hosts: fess-servers


### PR DESCRIPTION
完了時のメッセージを表示する際に以下のエラーが発生しました。

```
TASK [debug] *********************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'ansible_default_ipv4' is undefined\n\nThe error appears to have been in '/tmp/redmine-centos-ansible/site.yml': line 12, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  post_tasks:\n    - debug: msg='Redmine instalation completed. access http://{{ ansible_default_ipv4.address }}/redmine/ '\n      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
	to retry, use: --limit @/tmp/redmine-centos-ansible/site.retry
```

また、いくつかtypoがあったので修正してみました。
