### PR TITLE
Changes a way to create system and ruby environment using Dockerfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Redmineインストール直後のadmin初期パスワードは admin で固定�
 
 そのため、情報セキュリテイ対策として、admin初期パスワードを変更しました。初期パスワードは必要に応じ変更ください。
 
-admin初期パスワード  unofficial-cracking 
+admin初期パスワード  unofficial-cracking
 
 ## システム構成
 
@@ -156,8 +156,9 @@ $ docker build -t redmine-centos-ansible docker
 ```
 $ docker run --privileged --name redmine-centos-ansible -d -p 8080:80 redmine-centos-ansible /sbin/init
 $ docker exec -ti redmine-centos-ansible /bin/bash
-＜コンテナに入ると、リポジトリをチェックアウトした状態のフォルダがカレントになっています。＞
-＜ここで上記に従い、パスワードの変更などを行ってください。＞
+# cd /tmp
+# git clone https://github.com/y503unavailable/redmine-centos-ansible.git
+$ cd redmine-centos-ansible
 # ansible-playbook -i hosts site.yml
 ```
 
@@ -182,7 +183,7 @@ Docker対応は  Tatsuya Saito <twopackas@gmail.com> によります。
 
 ## 本プレイブックについて
 
-原作 
+原作
 [ファーエンドテクノロジー株式会社](http://www.farend.co.jp/)
 https://github.com/farend/redmine-centos-ansible
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,25 +2,58 @@ FROM centos:7
 
 MAINTAINER Tatsuya Saito <twopackas@gmail.com>
 
-RUN yum -y update && \
-    yum install -y epel-release && \
-    yum-config-manager --enable epel
+RUN yum -y clean all && \
+    yum -y update && \
+    yum -y install yum-plugin-ovl
+
+RUN yum install -y epel-release centos-release-scl-rh && \
+    yum-config-manager --enable epel && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum -y clean all && \
+    yum -y update
 
 RUN rm -f /etc/rpm/macros.image-language-conf && \
     sed -i '/^override_install_langs=/d' /etc/yum.conf && \
-    yum -y reinstall glibc-common && \
-    yum clean all
+    yum -y reinstall glibc-common
 
-ENV LANG="ja_JP.UTF-8" \
-    LANGUAGE="ja_JP:ja" \
-    LC_ALL="ja_JP.UTF-8"
+RUN yum install -y which selinux-policy firewalld scl-utils
 
-RUN yum install -y which && \
-    yum install -y selinux-policy && \
-    yum install -y firewalld && \
-    yum install -y ansible git
+RUN yum groups mark install "Development Tools" && \
+    yum groups mark convert "Development Tools" && \
+    yum group install -y "Development Tools"
 
-WORKDIR /tmp
-RUN git clone -b 3.4-unofficialcooking https://github.com/y503unavailable/redmine-centos-ansible.git
+RUN yum install -y ansible git openssl-devel readline-devel zlib-devel \
+                   curl-devel libyaml-devel libffi-devel httpd httpd-devel \
+                   ImageMagick ImageMagick-devel ipa-pgothic-fonts \
+                   subversion ssmtp mariadb-server mariadb-devel MySQL-python
 
-WORKDIR /tmp/redmine-centos-ansible
+RUN yum install -y rh-ruby24 rh-ruby24-ruby-devel
+RUN source scl_source enable rh-ruby24 && \
+    echo -e '#!/bin/bash\nsource scl_source enable rh-ruby24' > /etc/profile.d/rh-ruby24.sh
+RUN ln -s /opt/rh/rh-ruby24/root/usr/lib64/libruby.so.2.4 /usr/lib64
+ENV PATH $PATH:/opt/rh/rh-ruby24/root/usr/bin:/opt/rh/rh-ruby24/root/usr/local/bin
+
+RUN gem install passenger --no-ri --no-rdoc -V
+RUN passenger-install-apache2-module --auto
+
+RUN echo '<Directory "/var/lib/redmine/public">' > /etc/httpd/conf.d/redmine.conf
+RUN echo '  Require all granted' >> /etc/httpd/conf.d/redmine.conf
+RUN echo '</Directory>' >> /etc/httpd/conf.d/redmine.conf
+RUN echo '' >> /etc/httpd/conf.d/redmine.conf
+RUN passenger-install-apache2-module --snippet >> /etc/httpd/conf.d/redmine.conf
+RUN echo '' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'Header always unset "X-Powered-By"' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'Header always unset "X-Runtime"' >> /etc/httpd/conf.d/redmine.conf
+RUN echo '' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'PassengerMaxPoolSize 20' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'PassengerMaxInstancesPerApp 4' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'PassengerPoolIdleTime 864000' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'PassengerHighPerformance on' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'PassengerStatThrottleRate 10' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'PassengerSpawnMethod smart' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'PassengerFriendlyErrorPages off' >> /etc/httpd/conf.d/redmine.conf
+RUN echo '' >> /etc/httpd/conf.d/redmine.conf
+RUN echo 'RackBaseURI /redmine' >> /etc/httpd/conf.d/redmine.conf
+
+RUN ln -s /var/lib/redmine/public /var/www/html/redmine
+RUN httpd -k restart

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,11 +29,15 @@ $ docker build -t redmine-centos-ansible docker
 
 ### Usage
 
+1. Run docker image.
 ```
 $ docker run --privileged --name redmine-centos-ansible -d -p 8080:80 twopackas/redmine-centos-ansible /sbin/init
 $ docker exec -ti redmine-centos-ansible /bin/bash
+```
+2. Clone this repository.
+3. Run playbook in cloned folder.
+```
 # ansible-playbook -i hosts site.yml
 ```
-
 
 After that, access to http://your-server:8080/redmine

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -31,6 +31,7 @@ ruby_archive_ext: tar.bz2
 ruby_archive_name: "{{ ruby_archive_version }}.{{ ruby_archive_ext }}"
 
 ruby_file_name: /usr/local/bin/ruby
+rh_ruby24_file_name: /opt/rh/rh-ruby24/root/usr/bin/ruby
 work_dir: /tmp/redmine-setup
 
 # theme初期値指定

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -5,7 +5,8 @@
 
 - name: Passengerがインストールされているか確認
   command:
-    test -f /usr/local/bin/passenger-install-apache2-module
+    test -f /usr/local/bin/passenger-install-apache2-module -o \
+         -f /opt/rh/rh-ruby24/root/usr/local/bin/passenger-install-apache2-module
   register:
     result
   failed_when: result.rc not in [0, 1]

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -38,11 +38,20 @@
     passenger_snippet_vars
   changed_when: false
 
+- name: redmine.confが作成済みか確認
+  command:
+    test -f /etc/httpd/conf.d/redmine.conf
+  register:
+    conf_exist
+  failed_when: conf_exist.rc not in [0, 1]
+  changed_when: false
+
 - name: redmine.confの作成
   become: yes
   template:
     src=redmine.conf.j2
     dest=/etc/httpd/conf.d/redmine.conf
+  when: conf_exist.rc == 1
 
 - name: Redmineに /redmine でアクセスするためのシンボリックリンク作成
   become: yes

--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Rubyがインストールされているか確認
   command:
-    test -f {{ ruby_file_name }}
+    test -f {{ ruby_file_name }} -o -f {{ rh_ruby24_file_name }}
   register:
     ruby_test_vars
   failed_when: ruby_test_vars.rc not in [0, 1]


### PR DESCRIPTION
RubyとPassengerのインストールをDockerfileで行うことで構築時間を短縮しました。
Rubyはrpmからインストールするように変更しています。
AnsibleのPlaybook側では、インストール済みを判断してスキップするようにすることで、Docker以外の場合への影響を抑えています。

イメージはDocker Hubでもビルドしています。
https://hub.docker.com/r/twopackas/redmine-centos-ansible/

関連： #7 , #15 